### PR TITLE
fix error in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func update(version string) error {
 	if err != nil {
 		return errors.New("could not locate executable path")
 	}
-	if err := selfupdate.UpdateTo(latest.AssetURL, exe); err != nil {
+	if err := selfupdate.UpdateTo(latest.AssetURL, latest.AssetName, exe); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %v", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())


### PR DESCRIPTION
```
not enough arguments in call to selfupdate.UpdateTo
	have (string, string)
	want (string, string, string)
```