### PR TITLE
fix flipped function arguments

### DIFF
--- a/package.go
+++ b/package.go
@@ -29,7 +29,7 @@ func UpdateTo(ctx context.Context, assetURL, assetFileName, cmdPath string) erro
 		return err
 	}
 	defer src.Close()
-	return up.decompressAndUpdate(src, assetURL, assetFileName, cmdPath)
+	return up.decompressAndUpdate(src, assetFileName, assetURL, cmdPath)
 }
 
 // UpdateCommand updates a given command binary to the latest version.


### PR DESCRIPTION
In package.go you send assetUrl to assetName and vice versa
https://github.com/creativeprojects/go-selfupdate/blob/ce6530a4d21d788d48970e49d83a2d9f88cadd27/package.go#L32

https://github.com/creativeprojects/go-selfupdate/blob/ce6530a4d21d788d48970e49d83a2d9f88cadd27/update.go#L92