### PR TITLE
Add support for setting old save path

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,4 +23,6 @@ type Config struct {
 	Draft bool
 	// Prerelease permits an upgrade to a "pre-release" version (default to false).
 	Prerelease bool
+	// To prevent automatic removal of the old binary, and allow you to test an update prior to manual removal.
+	OldSavePath string
 }

--- a/update.go
+++ b/update.go
@@ -99,7 +99,8 @@ func (up *Updater) decompressAndUpdate(src io.Reader, assetName, assetURL, cmdPa
 
 	log.Printf("Will update %s to the latest downloaded from %s", cmdPath, assetURL)
 	return update.Apply(asset, update.Options{
-		TargetPath: cmdPath,
+		TargetPath:  cmdPath,
+		OldSavePath: up.oldSavePath,
 	})
 }
 

--- a/updater.go
+++ b/updater.go
@@ -19,6 +19,7 @@ type Updater struct {
 	universalArch string // only filled in when needed
 	prerelease    bool
 	draft         bool
+	oldSavePath   string
 }
 
 // keep the default updater instance in cache
@@ -71,6 +72,7 @@ func NewUpdater(config Config) (*Updater, error) {
 		universalArch: universalArch,
 		prerelease:    config.Prerelease,
 		draft:         config.Draft,
+		oldSavePath:   config.OldSavePath,
 	}, nil
 }
 


### PR DESCRIPTION
I had a need for manually validating the update prior to committing to an update, and the upstream project inconshreveable/go-update has that as an option but it isn't exposed. This exposes it so I can utilize it without customizing things by copying your code into my code base.