### PR TITLE
Workaround to Windows filepath.EvalSymlinks() known issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/xanzy/go-gitlab v0.115.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/oauth2 v0.25.0
+	golang.org/x/sys v0.29.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -24,6 +25,5 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 )

--- a/internal/path.go
+++ b/internal/path.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"os"
-	"path/filepath"
 )
 
 // GetExecutablePath returns the path of the executable file with all symlinks resolved.
@@ -12,7 +11,7 @@ func GetExecutablePath() (string, error) {
 		return "", err
 	}
 
-	exe, err = filepath.EvalSymlinks(exe)
+	exe, err = ResolvePath(exe)
 	if err != nil {
 		return "", err
 	}

--- a/internal/resolve_path_unix.go
+++ b/internal/resolve_path_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package internal
+
+import (
+	"path/filepath"
+)
+
+// ResolvePath returns the path of a given filename with all symlinks resolved.
+func ResolvePath(filename string) (string, error) {
+	finalPath, err := filepath.EvalSymlinks(filename)
+	if err != nil {
+		return "", err
+	}
+
+	return finalPath, nil
+}

--- a/internal/resolve_path_windows.go
+++ b/internal/resolve_path_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package internal
+
+import (
+	"golang.org/x/sys/windows"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// ResolvePath returns the path of a given filename with all symlinks resolved.
+func ResolvePath(filename string) (string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	handle := windows.Handle(f.Fd())
+	buf := make([]uint16, syscall.MAX_PATH)
+	_, err = windows.GetFinalPathNameByHandle(handle, &buf[0], uint32(len(buf)), 0)
+	if err != nil {
+		return "", err
+	}
+	final := syscall.UTF16ToString(buf)
+
+	// Strip possible "\\?\" prefix
+	final = strings.TrimPrefix(final, `\\?\`)
+
+	return final, nil
+}

--- a/update.go
+++ b/update.go
@@ -54,7 +54,7 @@ func (up *Updater) UpdateCommand(ctx context.Context, cmdPath string, current st
 		return nil, fmt.Errorf("failed to stat '%s'. file may not exist: %s", cmdPath, err)
 	}
 	if stat.Mode()&os.ModeSymlink != 0 {
-		p, err := filepath.EvalSymlinks(cmdPath)
+		p, err := internal.ResolvePath(cmdPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve symlink '%s' for executable: %s", cmdPath, err)
 		}


### PR DESCRIPTION
We're using `go-selfupdate` v.1.4.1 [in our CLI project](https://github.com/metaplay/cli/blob/main/cmd/update_cli.go) and the self-update fails on Windows with the following configuration:

![Image](https://github.com/user-attachments/assets/2e920613-f761-4f69-a3ba-941604b8e2a7)

(not visible in the image, but there's 64GB of RAM on the system)

The error originates from `selfupdate.ExecutablePath()` and more specifically, from a call to `filepath.EvalSymLinks()`within. This function appears to be notoriously unreliable on Windows, see e.g. https://github.com/golang/go/issues/42201 

This PR introduces a new internal function `internal.ResolvePath()` as a replacement for direct `filepath.EvalSymlinks()` calls. The implementation uses `x/sys/windows.GetFinalPathNameByHandle()` on Windows, and `filepath.EvalSymlinks()` on unix(-like) platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Refined dependency management by directly incorporating critical system dependencies.
  
- **New Features**
	- Enhanced symbolic link resolution for executables and command paths.
	- Introduced platform-specific logic to ensure more reliable operation on both Unix and Windows environments.
	- Added a new method for resolving paths in both Unix and Windows environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->