### PR TITLE
add binary file name in new release option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,16 @@ func update(version string) error {
 		return nil
 	}
 
-	exe, err := selfupdate.ExecutablePath()
+	cmdPath, err := selfupdate.ExecutablePath()
 	if err != nil {
-		return errors.New("could not locate executable path")
+		return fmt.Errorf("could not locate executable path: %w", err)
 	}
-	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, latest.AssetName, exe); err != nil {
+
+    // In the new release, the binary file can have any name — this is set by the relExe.
+	// If it has the same name as the old one, you can get it like this:
+	_, relExe := filepath.Split(cmdPath)
+
+	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, relExe, cmdPath); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %w", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())
@@ -346,7 +351,7 @@ See [goreleaser documentation](https://goreleaser.com/scm/gitlab/#generic-packag
 ## Example:
 
 ```go
-func update() {
+func update() error {
 	source, err := selfupdate.NewGitLabSource(selfupdate.GitLabConfig{
 		BaseURL: "https://private.instance.on.gitlab.com/",
 	})
@@ -365,19 +370,25 @@ func update() {
 		log.Fatal(err)
 	}
 	if !found {
-		log.Print("Release not found")
-		return
+		return errors.New("release not found")
 	}
 	fmt.Printf("found release %s\n", release.Version())
 
-	exe, err := selfupdate.ExecutablePath()
+	cmdPath, err := selfupdate.ExecutablePath()
 	if err != nil {
 		return errors.New("could not locate executable path")
 	}
-	err = updater.UpdateTo(context.Background(), release, exe)
+
+	// In the new release, the binary file can have any name — this is set by the relExe.
+	// If it has the same name as the old one, you can get it like this:
+	_, relExe := filepath.Split(cmdPath)
+
+	err = updater.UpdateTo(context.Background(), release, relExe, cmdPath)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	return nil
 }
 ```
 
@@ -392,7 +403,7 @@ The HttpSource is designed to work with repositories built using [goreleaser-htt
 If your repository is at example.com/repo/project, then you'd use the following example.
 
 ```go
-func update() {
+func update() error {
 	source, err := selfupdate.NewHttpSource(selfupdate.HttpConfig{
 		BaseURL: "https://example.com/",
 	})
@@ -411,19 +422,25 @@ func update() {
 		log.Fatal(err)
 	}
 	if !found {
-		log.Print("Release not found")
-		return
+		return errors.New("release not found")
 	}
 	fmt.Printf("found release %s\n", release.Version())
 
-	exe, err := selfupdate.ExecutablePath()
+	cmdPath, err := selfupdate.ExecutablePath()
 	if err != nil {
 		return errors.New("could not locate executable path")
 	}
-	err = updater.UpdateTo(context.Background(), release, exe)
+
+	// In the new release, the binary file can have any name — this is set by the relExe.
+	// If it has the same name as the old one, you can get it like this:
+	_, relExe := filepath.Split(cmdPath)
+
+	err = updater.UpdateTo(context.Background(), release, relExe, cmdPath)
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	return nil
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Here's an example how to use the library for an application to update itself
 
 ```go
 func update(version string) error {
-	latest, found, err := selfupdate.DetectLatest(context.Background(), selfupdate.ParseSlug("creativeprojects/resticprofile"))
+	latest, found, err := selfupdate.DetectLatest(
+		context.Background(),
+		selfupdate.DetectLatestOpt{Repository: selfupdate.ParseSlug("creativeprojects/resticprofile")},
+	)
 	if err != nil {
 		return fmt.Errorf("error occurred while detecting version: %w", err)
 	}
@@ -90,11 +93,9 @@ func update(version string) error {
 		return fmt.Errorf("could not locate executable path: %w", err)
 	}
 
-    // In the new release, the binary file can have any name — this is set by the relExe.
-	// If it has the same name as the old one, you can get it like this:
-	_, relExe := filepath.Split(cmdPath)
-
-	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, relExe, cmdPath); err != nil {
+	// In the new release, the binary file can have any name — this is set by the selfupdate.UpdateToOpt.RelExe.
+	// If it's the same as the old one, then selfupdate.UpdateToOpt.RelExe should be empty.
+	if err := selfupdate.UpdateTo(context.Background(), selfupdate.UpdateToOpt{Rel: latest, CmdPath: cmdPath}); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %w", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())
@@ -365,7 +366,10 @@ func update() error {
 	if err != nil {
 		log.Fatal(err)
 	}
-	release, found, err := updater.DetectLatest(context.Background(), selfupdate.NewRepositorySlug("owner", "cli-tool"))
+	release, found, err := updater.DetectLatest(
+		context.Background(),
+		selfupdate.DetectLatestOpt{Repository: selfupdate.NewRepositorySlug("owner", "cli-tool")},
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -379,11 +383,9 @@ func update() error {
 		return errors.New("could not locate executable path")
 	}
 
-	// In the new release, the binary file can have any name — this is set by the relExe.
-	// If it has the same name as the old one, you can get it like this:
-	_, relExe := filepath.Split(cmdPath)
-
-	err = updater.UpdateTo(context.Background(), release, relExe, cmdPath)
+	// In the new release, the binary file can have any name — this is set by the selfupdate.UpdateToOpt.RelExe.
+	// If it's the same as the old one, then selfupdate.UpdateToOpt.RelExe should be empty.
+	err = updater.UpdateTo(context.Background(), selfupdate.UpdateToOpt{Rel: release, CmdPath: cmdPath})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -417,7 +419,10 @@ func update() error {
 	if err != nil {
 		log.Fatal(err)
 	}
-	release, found, err := updater.DetectLatest(context.Background(), selfupdate.NewRepositorySlug("repo", "project"))
+	release, found, err := updater.DetectLatest(
+		context.Background(),
+		selfupdate.DetectLatestOpt{Repository: selfupdate.NewRepositorySlug("repo", "project")},
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -431,11 +436,9 @@ func update() error {
 		return errors.New("could not locate executable path")
 	}
 
-	// In the new release, the binary file can have any name — this is set by the relExe.
-	// If it has the same name as the old one, you can get it like this:
-	_, relExe := filepath.Split(cmdPath)
-
-	err = updater.UpdateTo(context.Background(), release, relExe, cmdPath)
+	// In the new release, the binary file can have any name — this is set by the selfupdate.UpdateToOpt.RelExe.
+	// If it's the same as the old one, then selfupdate.UpdateToOpt.RelExe should be empty.
+	err = updater.UpdateTo(context.Background(), selfupdate.UpdateToOpt{Rel: release, CmdPath: cmdPath})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/detect-latest-release/main.go
+++ b/cmd/detect-latest-release/main.go
@@ -87,7 +87,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	latest, found, err := updater.DetectLatest(context.Background(), selfupdate.ParseSlug(slug))
+	latest, found, err := updater.DetectLatest(context.Background(), selfupdate.DetectLatestOpt{Repository: selfupdate.ParseSlug(slug)})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/detect-latest-release/update.go
+++ b/cmd/detect-latest-release/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"path/filepath"
 	"runtime"
 
 	"github.com/creativeprojects/go-selfupdate"
@@ -26,11 +27,16 @@ func update(version string) error {
 		return nil
 	}
 
-	exe, err := selfupdate.ExecutablePath()
+	cmdPath, err := selfupdate.ExecutablePath()
 	if err != nil {
 		return fmt.Errorf("could not locate executable path: %w", err)
 	}
-	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, latest.AssetName, exe); err != nil {
+
+	// In the new release, the binary file can have any name — this is set by the relExe.
+	// If it has the same name as the old one, you can get it like this:
+	_, relExe := filepath.Split(cmdPath)
+
+	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, relExe, cmdPath); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %w", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())

--- a/cmd/detect-latest-release/update.go
+++ b/cmd/detect-latest-release/update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"path/filepath"
 	"runtime"
 
 	"github.com/creativeprojects/go-selfupdate"
@@ -14,7 +13,10 @@ import (
 //
 //nolint:unused
 func update(version string) error {
-	latest, found, err := selfupdate.DetectLatest(context.Background(), selfupdate.ParseSlug("creativeprojects/resticprofile"))
+	latest, found, err := selfupdate.DetectLatest(
+		context.Background(),
+		selfupdate.DetectLatestOpt{Repository: selfupdate.ParseSlug("creativeprojects/resticprofile")},
+	)
 	if err != nil {
 		return fmt.Errorf("error occurred while detecting version: %w", err)
 	}
@@ -32,11 +34,9 @@ func update(version string) error {
 		return fmt.Errorf("could not locate executable path: %w", err)
 	}
 
-	// In the new release, the binary file can have any name — this is set by the relExe.
-	// If it has the same name as the old one, you can get it like this:
-	_, relExe := filepath.Split(cmdPath)
-
-	if err := selfupdate.UpdateTo(context.Background(), latest.AssetURL, relExe, cmdPath); err != nil {
+	// In the new release, the binary file can have any name — this is set by the selfupdate.UpdateToOpt.RelExe.
+	// If it's the same as the old one, then selfupdate.UpdateToOpt.RelExe should be empty.
+	if err := selfupdate.UpdateTo(context.Background(), selfupdate.UpdateToOpt{Rel: latest, CmdPath: cmdPath}); err != nil {
 		return fmt.Errorf("error occurred while updating binary: %w", err)
 	}
 	log.Printf("Successfully updated to version %s", latest.Version())

--- a/cmd/get-release/main.go
+++ b/cmd/get-release/main.go
@@ -28,7 +28,7 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 
-	if help || flag.NArg() != 1 {
+	if help || flag.NArg() != 2 {
 		usage()
 		return
 	}
@@ -38,6 +38,7 @@ func main() {
 	}
 
 	repo := flag.Arg(0)
+	relExe := flag.Arg(1)
 
 	domain, slug, err := cmd.SplitDomainSlug(repo)
 	if err != nil {
@@ -77,16 +78,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmd := getCommand(flag.Arg(0))
+	cmd := getCommand(repo)
 	cmdPath := filepath.Join(build.Default.GOPATH, "bin", cmd)
 	if _, err := os.Stat(cmdPath); err != nil {
 		// When executable is not existing yet
-		if err := installFrom(ctx, latest.AssetURL, cmd, cmdPath); err != nil {
+		if err := installFrom(ctx, latest.AssetURL, relExe, cmdPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Error while installing the release binary from %s: %s\n", latest.AssetURL, err)
 			os.Exit(1)
 		}
 	} else {
-		if err := updater.UpdateTo(ctx, latest, cmdPath); err != nil {
+		if err := updater.UpdateTo(ctx, latest, relExe, cmdPath); err != nil {
 			fmt.Fprintf(os.Stderr, "Error while replacing the binary with %s: %s\n", latest.AssetURL, err)
 			os.Exit(1)
 		}
@@ -101,10 +102,11 @@ Release Notes:
 
 func usage() {
 	fmt.Fprintln(os.Stderr, `
-Usage: get-release [flags] {package}
+Usage: get-release [flags] {package} {relExe}
 
   get-release is like "go get github.com/owner/repo@latest".
   {package} is using the same format: "github.com/owner/repo".
+  {relExe} is the name of the new executable file (usually inside a release archive).
 
 Flags:`)
 	flag.PrintDefaults()
@@ -116,7 +118,7 @@ func getCommand(pkg string) string {
 	return cmd
 }
 
-func installFrom(ctx context.Context, url, cmd, path string) error {
+func installFrom(ctx context.Context, url, relExe, path string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("failed to create request to download release binary from %s: %s", url, err)
@@ -129,7 +131,7 @@ func installFrom(ctx context.Context, url, cmd, path string) error {
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to download release binary from %s: Invalid response ", url)
 	}
-	executable, err := selfupdate.DecompressCommand(res.Body, url, cmd, runtime.GOOS, runtime.GOARCH)
+	executable, err := selfupdate.DecompressCommand(res.Body, url, relExe, runtime.GOOS, runtime.GOARCH)
 	if err != nil {
 		return fmt.Errorf("failed to decompress downloaded asset from %s: %s", url, err)
 	}

--- a/cmd/get-release/main.go
+++ b/cmd/get-release/main.go
@@ -68,7 +68,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	latest, found, err := updater.DetectLatest(ctx, selfupdate.ParseSlug(slug))
+	latest, found, err := updater.DetectLatest(ctx, selfupdate.DetectLatestOpt{Repository: selfupdate.ParseSlug(slug)})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error while detecting the latest version:", err)
 		os.Exit(1)
@@ -87,7 +87,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		if err := updater.UpdateTo(ctx, latest, relExe, cmdPath); err != nil {
+		if err := updater.UpdateTo(ctx, selfupdate.UpdateToOpt{Rel: latest, RelExe: relExe, CmdPath: cmdPath}); err != nil {
 			fmt.Fprintf(os.Stderr, "Error while replacing the binary with %s: %s\n", latest.AssetURL, err)
 			os.Exit(1)
 		}
@@ -131,7 +131,13 @@ func installFrom(ctx context.Context, url, relExe, path string) error {
 	if res.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to download release binary from %s: Invalid response ", url)
 	}
-	executable, err := selfupdate.DecompressCommand(res.Body, url, relExe, runtime.GOOS, runtime.GOARCH)
+	executable, err := selfupdate.DecompressCommand(selfupdate.DecompressCommandOpt{
+		Src:    res.Body,
+		Url:    url,
+		RelExe: relExe,
+		Os:     runtime.GOOS,
+		Arch:   runtime.GOARCH,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to decompress downloaded asset from %s: %s", url, err)
 	}

--- a/decompress.go
+++ b/decompress.go
@@ -19,7 +19,7 @@ import (
 var (
 	fileTypes = []struct {
 		ext        string
-		decompress func(src io.Reader, cmd, os, arch string) (io.Reader, error)
+		decompress func(src io.Reader, relExe, os, arch string) (io.Reader, error)
 	}{
 		{".zip", unzip},
 		{".tar.gz", untar},
@@ -37,23 +37,23 @@ var (
 // DecompressCommand decompresses the given source. Archive and compression format is
 // automatically detected from 'url' parameter, which represents the URL of asset,
 // or simply a filename (with an extension).
-// This returns a reader for the decompressed command given by 'cmd'. '.zip',
+// This returns a reader for the decompressed command given by 'url'. '.zip',
 // '.tar.gz', '.tar.xz', '.tgz', '.gz', '.bz2' and '.xz' are supported.
 //
 // These wrapped errors can be returned:
 //   - ErrCannotDecompressFile
 //   - ErrExecutableNotFoundInArchive
-func DecompressCommand(src io.Reader, url, cmd, os, arch string) (io.Reader, error) {
+func DecompressCommand(src io.Reader, url, relExe, os, arch string) (io.Reader, error) {
 	for _, fileType := range fileTypes {
 		if strings.HasSuffix(url, fileType.ext) {
-			return fileType.decompress(src, cmd, os, arch)
+			return fileType.decompress(src, relExe, os, arch)
 		}
 	}
 	log.Print("File is not compressed")
 	return src, nil
 }
 
-func unzip(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func unzip(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing zip file")
 
 	// Zip format requires its file size for Decompressing.
@@ -70,17 +70,17 @@ func unzip(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 	}
 
 	for _, file := range z.File {
-		_, name := filepath.Split(file.Name)
-		if !file.FileInfo().IsDir() && matchExecutableName(cmd, os, arch, name) {
+		_, target := filepath.Split(file.Name)
+		if !file.FileInfo().IsDir() && matchExecutableName(relExe, os, arch, target) {
 			log.Printf("Executable file %q was found in zip archive", file.Name)
 			return file.Open()
 		}
 	}
 
-	return nil, fmt.Errorf("%w in zip file: %q", ErrExecutableNotFoundInArchive, cmd)
+	return nil, fmt.Errorf("%w in zip file: %q", ErrExecutableNotFoundInArchive, relExe)
 }
 
-func untar(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func untar(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing tar.gz file")
 
 	gz, err := gzip.NewReader(src)
@@ -88,10 +88,10 @@ func untar(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 		return nil, fmt.Errorf("%w tar.gz file: %s", ErrCannotDecompressFile, err)
 	}
 
-	return unarchiveTar(gz, cmd, os, arch)
+	return unarchiveTar(gz, relExe, os, arch)
 }
 
-func gunzip(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func gunzip(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing gzip file")
 
 	r, err := gzip.NewReader(src)
@@ -99,16 +99,16 @@ func gunzip(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 		return nil, fmt.Errorf("%w gzip file: %s", ErrCannotDecompressFile, err)
 	}
 
-	name := r.Name
-	if !matchExecutableName(cmd, os, arch, name) {
-		return nil, fmt.Errorf("%w: expected %q but found %q", ErrExecutableNotFoundInArchive, cmd, name)
+	target := r.Name
+	if !matchExecutableName(relExe, os, arch, target) {
+		return nil, fmt.Errorf("%w: expected %q but found %q", ErrExecutableNotFoundInArchive, relExe, target)
 	}
 
-	log.Printf("Executable file %q was found in gzip file", name)
+	log.Printf("Executable file %q was found in gzip file", target)
 	return r, nil
 }
 
-func untarxz(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func untarxz(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing tar.xz file")
 
 	xzip, err := xz.NewReader(src)
@@ -116,10 +116,10 @@ func untarxz(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 		return nil, fmt.Errorf("%w tar.xz file: %s", ErrCannotDecompressFile, err)
 	}
 
-	return unarchiveTar(xzip, cmd, os, arch)
+	return unarchiveTar(xzip, relExe, os, arch)
 }
 
-func unxz(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func unxz(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing xzip file")
 
 	xzip, err := xz.NewReader(src)
@@ -127,25 +127,25 @@ func unxz(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 		return nil, fmt.Errorf("%w xzip file: %s", ErrCannotDecompressFile, err)
 	}
 
-	log.Printf("Decompressed file from xzip is assumed to be an executable: %s", cmd)
+	log.Printf("Decompressed file from xzip is assumed to be an executable: %s", relExe)
 	return xzip, nil
 }
 
-func unbz2(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func unbz2(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	log.Print("Decompressing bzip2 file")
 
 	bz2 := bzip2.NewReader(src)
 
-	log.Printf("Decompressed file from bzip2 is assumed to be an executable: %s", cmd)
+	log.Printf("Decompressed file from bzip2 is assumed to be an executable: %s", relExe)
 	return bz2, nil
 }
 
-func matchExecutableName(cmd, os, arch, target string) bool {
-	cmd = strings.TrimSuffix(cmd, ".exe")
+func matchExecutableName(relExe, os, arch, target string) bool {
+	relExe = strings.TrimSuffix(relExe, ".exe")
 	pattern := regexp.MustCompile(
 		fmt.Sprintf(
 			`^%s([_-]v?%s)?([_-]%s[_-]%s)?(\.exe)?$`,
-			regexp.QuoteMeta(cmd),
+			regexp.QuoteMeta(relExe),
 			semverPattern,
 			regexp.QuoteMeta(os),
 			regexp.QuoteMeta(arch),
@@ -154,7 +154,7 @@ func matchExecutableName(cmd, os, arch, target string) bool {
 	return pattern.MatchString(target)
 }
 
-func unarchiveTar(src io.Reader, cmd, os, arch string) (io.Reader, error) {
+func unarchiveTar(src io.Reader, relExe, os, arch string) (io.Reader, error) {
 	t := tar.NewReader(src)
 	for {
 		h, err := t.Next()
@@ -164,11 +164,11 @@ func unarchiveTar(src io.Reader, cmd, os, arch string) (io.Reader, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%w tar file: %s", ErrCannotDecompressFile, err)
 		}
-		_, name := filepath.Split(h.Name)
-		if matchExecutableName(cmd, os, arch, name) {
+		_, target := filepath.Split(h.Name)
+		if matchExecutableName(relExe, os, arch, target) {
 			log.Printf("Executable file %q was found in tar archive", h.Name)
 			return t, nil
 		}
 	}
-	return nil, fmt.Errorf("%w in tar: %q", ErrExecutableNotFoundInArchive, cmd)
+	return nil, fmt.Errorf("%w in tar: %q", ErrExecutableNotFoundInArchive, relExe)
 }

--- a/decompress.go
+++ b/decompress.go
@@ -34,8 +34,16 @@ var (
 	semverPattern = `(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 )
 
+type DecompressCommandOpt struct {
+	Src io.Reader
+	Url,
+	RelExe,
+	Os,
+	Arch string
+}
+
 // DecompressCommand decompresses the given source. Archive and compression format is
-// automatically detected from 'url' parameter, which represents the URL of asset,
+// automatically detected from 'opt.url' parameter, which represents the URL of asset,
 // or simply a filename (with an extension).
 // This returns a reader for the decompressed command given by 'url'. '.zip',
 // '.tar.gz', '.tar.xz', '.tgz', '.gz', '.bz2' and '.xz' are supported.
@@ -43,14 +51,14 @@ var (
 // These wrapped errors can be returned:
 //   - ErrCannotDecompressFile
 //   - ErrExecutableNotFoundInArchive
-func DecompressCommand(src io.Reader, url, relExe, os, arch string) (io.Reader, error) {
+func DecompressCommand(opt DecompressCommandOpt) (io.Reader, error) {
 	for _, fileType := range fileTypes {
-		if strings.HasSuffix(url, fileType.ext) {
-			return fileType.decompress(src, relExe, os, arch)
+		if strings.HasSuffix(opt.Url, fileType.ext) {
+			return fileType.decompress(opt.Src, opt.RelExe, opt.Os, opt.Arch)
 		}
 	}
 	log.Print("File is not compressed")
-	return src, nil
+	return opt.Src, nil
 }
 
 func unzip(src io.Reader, relExe, os, arch string) (io.Reader, error) {

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -16,7 +16,7 @@ import (
 func TestCompressionNotRequired(t *testing.T) {
 	buf := []byte{'a', 'b', 'c'}
 	want := bytes.NewReader(buf)
-	r, err := DecompressCommand(want, "https://github.com/foo/bar/releases/download/v1.2.3/foo", "foo", runtime.GOOS, runtime.GOOS)
+	r, err := DecompressCommand(DecompressCommandOpt{want, "https://github.com/foo/bar/releases/download/v1.2.3/foo", "foo", runtime.GOOS, runtime.GOOS})
 	require.NoError(t, err)
 
 	have, err := io.ReadAll(r)
@@ -52,7 +52,7 @@ func TestDecompress(t *testing.T) {
 
 			ext := getArchiveFileExt(testCase)
 			url := "https://github.com/foo/bar/releases/download/v1.2.3/bar" + ext
-			r, err := DecompressCommand(f, url, "bar", runtime.GOOS, runtime.GOOS)
+			r, err := DecompressCommand(DecompressCommandOpt{f, url, "bar", runtime.GOOS, runtime.GOOS})
 			require.NoError(t, err)
 
 			content, err := io.ReadAll(r)
@@ -81,7 +81,7 @@ func TestDecompressInvalidArchive(t *testing.T) {
 
 		ext := getArchiveFileExt(testCase.name)
 		url := "https://github.com/foo/bar/releases/download/v1.2.3/bar" + ext
-		_, err = DecompressCommand(f, url, "bar", runtime.GOOS, runtime.GOOS)
+		_, err = DecompressCommand(DecompressCommandOpt{f, url, "bar", runtime.GOOS, runtime.GOOS})
 		assert.ErrorIs(t, err, ErrCannotDecompressFile)
 		if !strings.Contains(err.Error(), testCase.msg) {
 			t.Fatal("Unexpected error:", err)
@@ -106,7 +106,7 @@ func TestTargetNotFound(t *testing.T) {
 
 			ext := getArchiveFileExt(testCase.name)
 			url := "https://github.com/foo/bar/releases/download/v1.2.3/bar" + ext
-			_, err = DecompressCommand(f, url, "bar", runtime.GOOS, runtime.GOOS)
+			_, err = DecompressCommand(DecompressCommandOpt{f, url, "bar", runtime.GOOS, runtime.GOOS})
 			assert.ErrorIs(t, err, ErrExecutableNotFoundInArchive)
 		})
 	}
@@ -189,7 +189,7 @@ func TestErrorFromReader(t *testing.T) {
 
 	for _, extension := range extensions {
 		t.Run(extension, func(t *testing.T) {
-			reader, err := DecompressCommand(&bogusReader{}, "foo."+extension, "foo."+extension, runtime.GOOS, runtime.GOARCH)
+			reader, err := DecompressCommand(DecompressCommandOpt{&bogusReader{}, "foo." + extension, "foo." + extension, runtime.GOOS, runtime.GOARCH})
 			if err != nil {
 				t.Log(err)
 				assert.ErrorIs(t, err, ErrCannotDecompressFile)

--- a/detect.go
+++ b/detect.go
@@ -11,6 +11,15 @@ import (
 
 var reVersion = regexp.MustCompile(`\d+\.\d+\.\d+`)
 
+type DetectLatestOpt struct {
+	Repository Repository
+}
+
+type DetectVersionOpt struct {
+	Repository Repository
+	Version    string
+}
+
 // DetectLatest tries to get the latest version from the source provider.
 // It fetches releases information from the source provider and find out the latest release with matching the tag names and asset names.
 // Drafts and pre-releases are ignored.
@@ -18,24 +27,24 @@ var reVersion = regexp.MustCompile(`\d+\.\d+\.\d+`)
 // '-' can also be used as a separator. File can be compressed with zip, gzip, xz, bzip2, tar&gzip or tar&xz.
 // So the asset can have a file extension for the corresponding compression format such as '.zip'.
 // On Windows, '.exe' also can be contained such as 'foo_windows_amd64.exe.zip'.
-func (up *Updater) DetectLatest(ctx context.Context, repository Repository) (release *Release, found bool, err error) {
-	return up.DetectVersion(ctx, repository, "")
+func (up *Updater) DetectLatest(ctx context.Context, opt DetectLatestOpt) (release *Release, found bool, err error) {
+	return up.DetectVersion(ctx, DetectVersionOpt{opt.Repository, ""})
 }
 
 // DetectVersion tries to get the given version from the source provider.
 // And version indicates the required version.
-func (up *Updater) DetectVersion(ctx context.Context, repository Repository, version string) (release *Release, found bool, err error) {
-	rels, err := up.source.ListReleases(ctx, repository)
+func (up *Updater) DetectVersion(ctx context.Context, opt DetectVersionOpt) (release *Release, found bool, err error) {
+	rels, err := up.source.ListReleases(ctx, opt.Repository)
 	if err != nil {
 		return nil, false, err
 	}
 
-	rel, asset, ver, found := up.findReleaseAndAsset(rels, version)
+	rel, asset, ver, found := up.findReleaseAndAsset(rels, opt.Version)
 	if !found {
 		return nil, false, nil
 	}
 
-	return up.validateReleaseAsset(repository, rel, asset, ver)
+	return up.validateReleaseAsset(opt.Repository, rel, asset, ver)
 }
 
 func (up *Updater) validateReleaseAsset(

--- a/detect_test.go
+++ b/detect_test.go
@@ -41,7 +41,7 @@ func TestDetectReleaseWithVersionPrefix(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			r, ok, err := testItem.updater.DetectLatest(context.Background(), testGithubRepository)
+			r, ok, err := testItem.updater.DetectLatest(context.Background(), DetectLatestOpt{testGithubRepository})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.True(t, ok, "Failed to detect latest")
@@ -79,7 +79,7 @@ func TestDetectVersionExisting(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			r, ok, err := testItem.updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+			r, ok, err := testItem.updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, testVersion})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.Truef(t, ok, "Failed to detect %s", testVersion)
@@ -106,7 +106,7 @@ func TestDetectVersionExistingWithNoValidationFile(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			_, _, err := testItem.updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+			_, _, err := testItem.updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, testVersion})
 			skipRateLimitExceeded(t, err)
 			assert.ErrorIs(t, err, ErrValidationAssetNotFound)
 		})
@@ -128,7 +128,7 @@ func TestDetectVersionNotExisting(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			r, ok, err := testItem.updater.DetectVersion(context.Background(), testGithubRepository, "foobar")
+			r, ok, err := testItem.updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, "foobar"})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.False(t, ok, "Failed to correctly detect foobar")
@@ -151,7 +151,7 @@ func TestDetectPrerelease(t *testing.T) {
 				Source:     mockSourceRepository(t),
 				Prerelease: testFixture.prerelease,
 			})
-			r, ok, err := updater.DetectLatest(context.Background(), RepositorySlug{owner: "owner", repo: "repo"})
+			r, ok, err := updater.DetectLatest(context.Background(), DetectLatestOpt{RepositorySlug{owner: "owner", repo: "repo"}})
 			require.NotNil(t, r)
 			assert.True(t, ok)
 			assert.NoError(t, err)
@@ -178,7 +178,7 @@ func TestDetectReleasesForVariousArchives(t *testing.T) {
 			require.NoError(t, err, "failed to create source")
 			updater, err := NewUpdater(Config{Source: source, Arch: "amd64"})
 			require.NoError(t, err, "failed to create updater")
-			r, ok, err := updater.DetectLatest(context.Background(), ParseSlug(tc.slug))
+			r, ok, err := updater.DetectLatest(context.Background(), DetectLatestOpt{ParseSlug(tc.slug)})
 			skipRateLimitExceeded(t, err)
 
 			assert.NoError(t, err, "fetch failed")
@@ -231,7 +231,7 @@ func TestDetectReleaseButNoAsset(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			_, ok, err := testItem.updater.DetectLatest(context.Background(), ParseSlug("rhysd/clever-f.vim"))
+			_, ok, err := testItem.updater.DetectLatest(context.Background(), DetectLatestOpt{ParseSlug("rhysd/clever-f.vim")})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.False(t, ok, "When no asset found, result should be marked as 'not found'")
@@ -254,7 +254,7 @@ func TestNonExistingRepo(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			_, ok, err := testItem.updater.DetectLatest(context.Background(), ParseSlug("rhysd/non-existing-repo"))
+			_, ok, err := testItem.updater.DetectLatest(context.Background(), DetectLatestOpt{ParseSlug("rhysd/non-existing-repo")})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.False(t, ok, "Release for non-existing repo should not be found")
@@ -277,7 +277,7 @@ func TestNoReleaseFound(t *testing.T) {
 			continue
 		}
 		t.Run(testItem.name, func(t *testing.T) {
-			_, ok, err := testItem.updater.DetectLatest(context.Background(), ParseSlug("rhysd/misc"))
+			_, ok, err := testItem.updater.DetectLatest(context.Background(), DetectLatestOpt{ParseSlug("rhysd/misc")})
 			skipRateLimitExceeded(t, err)
 			require.NoError(t, err)
 			assert.False(t, ok, "Repo having no release should not be found")
@@ -928,7 +928,7 @@ func TestBuildMultistepValidationChain(t *testing.T) {
 			Validator: NewChecksumWithPGPValidator("checksums.txt", keyRing),
 		})
 
-		release, found, err := updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+		release, found, err := updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, testVersion})
 		require.True(t, found)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(release.ValidationChain))
@@ -943,7 +943,7 @@ func TestBuildMultistepValidationChain(t *testing.T) {
 				Add("*", checksumValidator),
 		})
 
-		_, _, err := updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+		_, _, err := updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, testVersion})
 		assert.NoError(t, err)
 	})
 
@@ -955,7 +955,7 @@ func TestBuildMultistepValidationChain(t *testing.T) {
 				Add("*", new(SHAValidator)),
 		})
 
-		_, _, err := updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+		_, _, err := updater.DetectVersion(context.Background(), DetectVersionOpt{testGithubRepository, testVersion})
 		assert.EqualError(t, err, "validation file not found: \"checksums.txt.sha256\"")
 	})
 }

--- a/http_source_test.go
+++ b/http_source_test.go
@@ -149,7 +149,7 @@ func TestHttpListAndDownloadReleaseAsset(t *testing.T) {
 	require.NoError(t, err)
 
 	// Find the latest release.
-	release, found, err := updater.DetectLatest(context.Background(), NewRepositorySlug("creativeprojects", "resticprofile"))
+	release, found, err := updater.DetectLatest(context.Background(), DetectLatestOpt{NewRepositorySlug("creativeprojects", "resticprofile")})
 	require.NoError(t, err)
 	assert.Equal(t, found, true, "no release found")
 

--- a/package.go
+++ b/package.go
@@ -24,7 +24,7 @@ func DetectVersion(ctx context.Context, repository Repository, version string) (
 // This function is low-level API to update the binary. Because it does not use a source provider and downloads asset directly from the URL via HTTP,
 // this function is not available to update a release for private repositories.
 // cmdPath is a file path to command executable.
-func UpdateTo(ctx context.Context, assetURL, assetFileName, cmdPath string) error {
+func UpdateTo(ctx context.Context, assetURL, relExe, cmdPath string) error {
 	//nolint:contextcheck
 	up := DefaultUpdater()
 	src, err := downloadReleaseAssetFromURL(ctx, assetURL)
@@ -32,21 +32,21 @@ func UpdateTo(ctx context.Context, assetURL, assetFileName, cmdPath string) erro
 		return err
 	}
 	defer src.Close()
-	return up.decompressAndUpdate(src, assetFileName, assetURL, cmdPath)
+	return up.decompressAndUpdate(src, assetURL, relExe, cmdPath)
 }
 
 // UpdateCommand updates a given command binary to the latest version.
 // This function is a shortcut version of updater.UpdateCommand using a DefaultUpdater()
-func UpdateCommand(ctx context.Context, cmdPath string, current string, repository Repository) (*Release, error) {
+func UpdateCommand(ctx context.Context, relExe, cmdPath string, current string, repository Repository) (*Release, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().UpdateCommand(ctx, cmdPath, current, repository)
+	return DefaultUpdater().UpdateCommand(ctx, relExe, cmdPath, current, repository)
 }
 
 // UpdateSelf updates the running executable itself to the latest version.
 // This function is a shortcut version of updater.UpdateSelf using a DefaultUpdater()
-func UpdateSelf(ctx context.Context, current string, repository Repository) (*Release, error) {
+func UpdateSelf(ctx context.Context, relExe, current string, repository Repository) (*Release, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().UpdateSelf(ctx, current, repository)
+	return DefaultUpdater().UpdateSelf(ctx, relExe, current, repository)
 }
 
 func downloadReleaseAssetFromURL(ctx context.Context, url string) (rc io.ReadCloser, err error) {

--- a/package.go
+++ b/package.go
@@ -9,44 +9,44 @@ import (
 
 // DetectLatest detects the latest release from the repository.
 // This function is a shortcut version of updater.DetectLatest with the DefaultUpdater.
-func DetectLatest(ctx context.Context, repository Repository) (*Release, bool, error) {
+func DetectLatest(ctx context.Context, opt DetectLatestOpt) (*Release, bool, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().DetectLatest(ctx, repository)
+	return DefaultUpdater().DetectLatest(ctx, opt)
 }
 
 // DetectVersion detects the given release from the repository.
-func DetectVersion(ctx context.Context, repository Repository, version string) (*Release, bool, error) {
+func DetectVersion(ctx context.Context, opt DetectVersionOpt) (*Release, bool, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().DetectVersion(ctx, repository, version)
+	return DefaultUpdater().DetectVersion(ctx, opt)
 }
 
 // UpdateTo downloads an executable from assetURL and replaces the current binary with the downloaded one.
 // This function is low-level API to update the binary. Because it does not use a source provider and downloads asset directly from the URL via HTTP,
 // this function is not available to update a release for private repositories.
 // cmdPath is a file path to command executable.
-func UpdateTo(ctx context.Context, assetURL, relExe, cmdPath string) error {
+func UpdateTo(ctx context.Context, opt UpdateToOpt) error {
 	//nolint:contextcheck
 	up := DefaultUpdater()
-	src, err := downloadReleaseAssetFromURL(ctx, assetURL)
+	src, err := downloadReleaseAssetFromURL(ctx, opt.Rel.AssetURL)
 	if err != nil {
 		return err
 	}
 	defer src.Close()
-	return up.decompressAndUpdate(src, assetURL, relExe, cmdPath)
+	return up.decompressAndUpdate(src, opt.Rel.AssetURL, opt.RelExe, opt.CmdPath)
 }
 
 // UpdateCommand updates a given command binary to the latest version.
 // This function is a shortcut version of updater.UpdateCommand using a DefaultUpdater()
-func UpdateCommand(ctx context.Context, relExe, cmdPath string, current string, repository Repository) (*Release, error) {
+func UpdateCommand(ctx context.Context, opt UpdateCommandOpt) (*Release, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().UpdateCommand(ctx, relExe, cmdPath, current, repository)
+	return DefaultUpdater().UpdateCommand(ctx, opt)
 }
 
 // UpdateSelf updates the running executable itself to the latest version.
 // This function is a shortcut version of updater.UpdateSelf using a DefaultUpdater()
-func UpdateSelf(ctx context.Context, relExe, current string, repository Repository) (*Release, error) {
+func UpdateSelf(ctx context.Context, opt UpdateSelfOpt) (*Release, error) {
 	//nolint:contextcheck
-	return DefaultUpdater().UpdateSelf(ctx, relExe, current, repository)
+	return DefaultUpdater().UpdateSelf(ctx, opt)
 }
 
 func downloadReleaseAssetFromURL(ctx context.Context, url string) (rc io.ReadCloser, err error) {

--- a/update.go
+++ b/update.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -16,7 +15,7 @@ import (
 
 // UpdateTo downloads an executable from the source provider and replace current binary with the downloaded one.
 // It downloads a release asset via the source provider so this function is available for update releases on private repository.
-func (up *Updater) UpdateTo(ctx context.Context, rel *Release, cmdPath string) error {
+func (up *Updater) UpdateTo(ctx context.Context, rel *Release, relExe, cmdPath string) error {
 	if rel == nil {
 		return ErrInvalidRelease
 	}
@@ -33,12 +32,12 @@ func (up *Updater) UpdateTo(ctx context.Context, rel *Release, cmdPath string) e
 		}
 	}
 
-	return up.decompressAndUpdate(bytes.NewReader(data), rel.AssetName, rel.AssetURL, cmdPath)
+	return up.decompressAndUpdate(bytes.NewReader(data), rel.AssetURL, relExe, cmdPath)
 }
 
 // UpdateCommand updates a given command binary to the latest version.
 // 'current' is used to check the latest version against the current version.
-func (up *Updater) UpdateCommand(ctx context.Context, cmdPath string, current string, repository Repository) (*Release, error) {
+func (up *Updater) UpdateCommand(ctx context.Context, relExe, cmdPath string, current string, repository Repository) (*Release, error) {
 	version, err := semver.NewVersion(current)
 	if err != nil {
 		return nil, fmt.Errorf("incorrect version %q: %w", current, err)
@@ -74,7 +73,7 @@ func (up *Updater) UpdateCommand(ctx context.Context, cmdPath string, current st
 		return rel, nil
 	}
 	log.Printf("Will update %s to the latest version %s", cmdPath, rel.Version())
-	if err := up.UpdateTo(ctx, rel, cmdPath); err != nil {
+	if err := up.UpdateTo(ctx, rel, relExe, cmdPath); err != nil {
 		return nil, err
 	}
 	return rel, nil
@@ -82,17 +81,16 @@ func (up *Updater) UpdateCommand(ctx context.Context, cmdPath string, current st
 
 // UpdateSelf updates the running executable itself to the latest version.
 // 'current' is used to check the latest version against the current version.
-func (up *Updater) UpdateSelf(ctx context.Context, current string, repository Repository) (*Release, error) {
+func (up *Updater) UpdateSelf(ctx context.Context, relExe, current string, repository Repository) (*Release, error) {
 	cmdPath, err := internal.GetExecutablePath()
 	if err != nil {
 		return nil, err
 	}
-	return up.UpdateCommand(ctx, cmdPath, current, repository)
+	return up.UpdateCommand(ctx, relExe, cmdPath, current, repository)
 }
 
-func (up *Updater) decompressAndUpdate(src io.Reader, assetName, assetURL, cmdPath string) error {
-	_, cmd := filepath.Split(cmdPath)
-	asset, err := DecompressCommand(src, assetName, cmd, up.os, up.arch)
+func (up *Updater) decompressAndUpdate(src io.Reader, assetURL, relExe, cmdPath string) error {
+	asset, err := DecompressCommand(src, assetURL, relExe, up.os, up.arch)
 	if err != nil {
 		return err
 	}

--- a/update.go
+++ b/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -13,54 +14,76 @@ import (
 	"github.com/creativeprojects/go-selfupdate/update"
 )
 
+type UpdateToOpt struct {
+	Rel *Release
+	RelExe,
+	CmdPath string
+}
+
+type UpdateCommandOpt struct {
+	RelExe,
+	CmdPath,
+	Current string
+	Repository Repository
+}
+
+type UpdateSelfOpt struct {
+	RelExe,
+	Current string
+	Repository Repository
+}
+
 // UpdateTo downloads an executable from the source provider and replace current binary with the downloaded one.
 // It downloads a release asset via the source provider so this function is available for update releases on private repository.
-func (up *Updater) UpdateTo(ctx context.Context, rel *Release, relExe, cmdPath string) error {
-	if rel == nil {
+func (up *Updater) UpdateTo(ctx context.Context, opt UpdateToOpt) error {
+	if opt.Rel == nil {
 		return ErrInvalidRelease
 	}
+	if opt.RelExe == "" {
+		_, opt.RelExe = filepath.Split(opt.CmdPath)
+	}
 
-	data, err := up.download(ctx, rel, rel.AssetID)
+	data, err := up.download(ctx, opt.Rel, opt.Rel.AssetID)
 	if err != nil {
-		return fmt.Errorf("failed to read asset %q: %w", rel.AssetName, err)
+		return fmt.Errorf("failed to read asset %q: %w", opt.Rel.AssetName, err)
 	}
 
 	if up.validator != nil {
-		err = up.validate(ctx, rel, data)
+		err = up.validate(ctx, opt.Rel, data)
 		if err != nil {
 			return err
 		}
 	}
 
-	return up.decompressAndUpdate(bytes.NewReader(data), rel.AssetURL, relExe, cmdPath)
+	return up.decompressAndUpdate(bytes.NewReader(data), opt.Rel.AssetURL, opt.RelExe, opt.CmdPath)
 }
 
 // UpdateCommand updates a given command binary to the latest version.
-// 'current' is used to check the latest version against the current version.
-func (up *Updater) UpdateCommand(ctx context.Context, relExe, cmdPath string, current string, repository Repository) (*Release, error) {
-	version, err := semver.NewVersion(current)
+// 'opt.Current' is used to check the latest version against the current version.
+func (up *Updater) UpdateCommand(ctx context.Context, opt UpdateCommandOpt) (*Release, error) {
+	version, err := semver.NewVersion(opt.Current)
 	if err != nil {
-		return nil, fmt.Errorf("incorrect version %q: %w", current, err)
+		return nil, fmt.Errorf("incorrect version %q: %w", opt.Current, err)
 	}
 
-	if up.os == "windows" && !strings.HasSuffix(cmdPath, ".exe") {
+	if up.os == "windows" && !strings.HasSuffix(opt.CmdPath, ".exe") {
 		// Ensure to add '.exe' to given path on Windows
-		cmdPath = cmdPath + ".exe"
+		opt.CmdPath = opt.CmdPath + ".exe"
 	}
 
-	stat, err := os.Lstat(cmdPath)
+	stat, err := os.Lstat(opt.CmdPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat '%s'. file may not exist: %s", cmdPath, err)
+		return nil, fmt.Errorf("failed to stat '%s'. file may not exist: %s", opt.CmdPath, err)
 	}
 	if stat.Mode()&os.ModeSymlink != 0 {
-		p, err := internal.ResolvePath(cmdPath)
+		p, err := internal.ResolvePath(opt.CmdPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve symlink '%s' for executable: %s", cmdPath, err)
+			return nil, fmt.Errorf("failed to resolve symlink '%s' for executable: %s", opt.CmdPath, err)
 		}
-		cmdPath = p
+		opt.CmdPath = p
 	}
 
-	rel, ok, err := up.DetectLatest(ctx, repository)
+	rel, ok, err := up.DetectLatest(ctx, DetectLatestOpt{opt.Repository})
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +95,8 @@ func (up *Updater) UpdateCommand(ctx context.Context, relExe, cmdPath string, cu
 		log.Printf("Current version %s is the latest. Update is not needed", version.String())
 		return rel, nil
 	}
-	log.Printf("Will update %s to the latest version %s", cmdPath, rel.Version())
-	if err := up.UpdateTo(ctx, rel, relExe, cmdPath); err != nil {
+	log.Printf("Will update %s to the latest version %s", opt.CmdPath, rel.Version())
+	if err := up.UpdateTo(ctx, UpdateToOpt{rel, opt.RelExe, opt.CmdPath}); err != nil {
 		return nil, err
 	}
 	return rel, nil
@@ -81,16 +104,16 @@ func (up *Updater) UpdateCommand(ctx context.Context, relExe, cmdPath string, cu
 
 // UpdateSelf updates the running executable itself to the latest version.
 // 'current' is used to check the latest version against the current version.
-func (up *Updater) UpdateSelf(ctx context.Context, relExe, current string, repository Repository) (*Release, error) {
+func (up *Updater) UpdateSelf(ctx context.Context, opt UpdateSelfOpt) (*Release, error) {
 	cmdPath, err := internal.GetExecutablePath()
 	if err != nil {
 		return nil, err
 	}
-	return up.UpdateCommand(ctx, relExe, cmdPath, current, repository)
+	return up.UpdateCommand(ctx, UpdateCommandOpt{opt.RelExe, cmdPath, opt.Current, opt.Repository})
 }
 
 func (up *Updater) decompressAndUpdate(src io.Reader, assetURL, relExe, cmdPath string) error {
-	asset, err := DecompressCommand(src, assetURL, relExe, up.os, up.arch)
+	asset, err := DecompressCommand(DecompressCommandOpt{src, assetURL, relExe, up.os, up.arch})
 	if err != nil {
 		return err
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestUpdateCommandWithWrongVersion(t *testing.T) {
-	_, err := UpdateCommand(context.Background(), "path", "wrong version", ParseSlug("test/test"))
+	_, err := UpdateCommand(context.Background(), "file", "path", "wrong version", ParseSlug("test/test"))
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, semver.ErrInvalidSemVer)
 }
@@ -30,7 +30,7 @@ func TestUpdateCommand(t *testing.T) {
 
 	filename := setupCurrentVersion(t)
 
-	rel, err := updater.UpdateCommand(context.Background(), filename, currentVersion, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), "new_version", filename, currentVersion, ParseSlug("creativeprojects/new_version"))
 	require.NoError(t, err)
 	assert.Equal(t, newVersion, rel.Version())
 
@@ -54,7 +54,7 @@ func TestUpdateViaSymlink(t *testing.T) {
 	err = os.Symlink(exePath, symPath)
 	require.NoError(t, err)
 
-	rel, err := updater.UpdateCommand(context.Background(), symPath, currentVersion, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), "new_version", symPath, currentVersion, ParseSlug("creativeprojects/new_version"))
 	require.NoError(t, err)
 	assert.Equal(t, newVersion, rel.Version())
 
@@ -91,16 +91,31 @@ func TestUpdateBrokenSymlinks(t *testing.T) {
 	defer os.Remove(xxx)
 
 	for _, filename := range []string{yyy, xxx} {
-		_, err := updater.UpdateCommand(context.Background(), filename, "0.14.0", ParseSlug("owner/repo"))
+		_, err := updater.UpdateCommand(context.Background(), filename, filename, "0.14.0", ParseSlug("owner/repo"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to resolve symlink")
 	}
 }
 
+func TestNotExistingExe(t *testing.T) {
+	asset := "https://github.com/rhysd-test/test-release-zip/releases/download/v1.2.3/github-release-test_linux_amd64.zip"
+	err := UpdateTo(context.Background(), asset, "not-existing-exe", "foo")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "executable not found in zip file")
+}
+
 func TestNotExistingCommandPath(t *testing.T) {
-	_, err := UpdateCommand(context.Background(), "not-existing-command-path", "1.2.2", ParseSlug("owner/repo"))
+	_, err := UpdateCommand(context.Background(), "not-existing-exe-name", "not-existing-command-path", "1.2.2", ParseSlug("owner/repo"))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "file may not exist")
+}
+
+func TestUpdateToInvalidRelease(t *testing.T) {
+	updater, err := NewUpdater(Config{Source: &MockSource{}})
+	require.NoError(t, err)
+
+	err = updater.UpdateTo(context.Background(), nil, "", "")
+	assert.ErrorIs(t, err, ErrInvalidRelease)
 }
 
 func TestNoReleaseFoundForUpdate(t *testing.T) {
@@ -109,7 +124,7 @@ func TestNoReleaseFoundForUpdate(t *testing.T) {
 	updater, err := NewUpdater(Config{Source: &MockSource{}})
 	require.NoError(t, err)
 
-	rel, err := updater.UpdateCommand(context.Background(), fake, finalVersion, ParseSlug("owner/repo"))
+	rel, err := updater.UpdateCommand(context.Background(), "fake-executable", fake, finalVersion, ParseSlug("owner/repo"))
 	assert.NoError(t, err)
 	assert.Equal(t, finalVersion, rel.Version())
 	assert.Empty(t, rel.URL)
@@ -124,7 +139,7 @@ func TestCurrentIsTheLatest(t *testing.T) {
 	require.NoError(t, err)
 
 	latest := "1.0.0"
-	rel, err := updater.UpdateCommand(context.Background(), filename, latest, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), "new_version", filename, latest, ParseSlug("creativeprojects/new_version"))
 	assert.NoError(t, err)
 	assert.Equal(t, latest, rel.Version())
 	assert.NotEmpty(t, rel.URL)
@@ -178,26 +193,26 @@ func TestBrokenBinaryUpdate(t *testing.T) {
 	updater, err := NewUpdater(Config{Source: source})
 	require.NoError(t, err)
 
-	_, err = updater.UpdateCommand(context.Background(), fake, "1.2.2", ParseSlug("rhysd-test/test-incorrect-release"))
+	_, err = updater.UpdateCommand(context.Background(), "fake-executable", fake, "1.2.2", ParseSlug("rhysd-test/test-incorrect-release"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decompress")
 }
 
 func TestInvalidSlugForUpdate(t *testing.T) {
 	fake := filepath.FromSlash("./testdata/fake-executable")
-	_, err := UpdateCommand(context.Background(), fake, "1.0.0", ParseSlug("rhysd/"))
+	_, err := UpdateCommand(context.Background(), "fake-executable", fake, "1.0.0", ParseSlug("rhysd/"))
 	assert.Error(t, err)
 }
 
 func TestInvalidAssetURL(t *testing.T) {
-	err := UpdateTo(context.Background(), "https://github.com/creativeprojects/non-existing-repo/releases/download/v1.2.3/foo.zip", "foo.zip", "foo")
+	err := UpdateTo(context.Background(), "https://github.com/creativeprojects/non-existing-repo/releases/download/v1.2.3/foo.zip", "foo", "foo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to download a release file")
 }
 
 func TestBrokenAsset(t *testing.T) {
 	asset := "https://github.com/rhysd-test/test-incorrect-release/releases/download/invalid/broken-zip.zip"
-	err := UpdateTo(context.Background(), asset, "broken-zip.zip", "foo")
+	err := UpdateTo(context.Background(), asset, "foo", "foo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decompress zip file")
 }
@@ -211,6 +226,7 @@ func TestBrokenGitHubEnterpriseURL(t *testing.T) {
 		context.Background(),
 		&Release{AssetURL: "https://example.com",
 			repository: NewRepositorySlug("test", "test")},
+		"foo",
 		"foo")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to call GitHub Releases API for getting the asset")
@@ -322,7 +338,7 @@ func TestUpdateToInvalidOwner(t *testing.T) {
 		repository: NewRepositorySlug("", "test"),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "")
+	err := updater.UpdateTo(context.Background(), release, "", "")
 	assert.EqualError(t, err, fmt.Sprintf("failed to read asset \"\": %s", ErrIncorrectParameterOwner.Error()))
 	assert.ErrorIs(t, err, ErrIncorrectParameterOwner)
 }
@@ -334,7 +350,7 @@ func TestUpdateToInvalidRepo(t *testing.T) {
 		repository: NewRepositorySlug("test", ""),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "")
+	err := updater.UpdateTo(context.Background(), release, "", "")
 	assert.EqualError(t, err, fmt.Sprintf("failed to read asset \"\": %s", ErrIncorrectParameterRepo.Error()))
 	assert.ErrorIs(t, err, ErrIncorrectParameterRepo)
 }
@@ -351,7 +367,7 @@ func TestUpdateToReadError(t *testing.T) {
 		repository: NewRepositorySlug("test", "test"),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "")
+	err := updater.UpdateTo(context.Background(), release, "", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errTestRead))
 }
@@ -380,7 +396,7 @@ func TestUpdateToWithWrongHash(t *testing.T) {
 		validator: &ChecksumValidator{},
 	}
 
-	err = updater.UpdateTo(context.Background(), release, "")
+	err = updater.UpdateTo(context.Background(), release, "", "")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrChecksumValidationFailed))
 }
@@ -411,7 +427,7 @@ func TestUpdateToSuccess(t *testing.T) {
 
 	tempfile := createEmptyFile(t, "foo")
 
-	err = updater.UpdateTo(context.Background(), release, tempfile)
+	err = updater.UpdateTo(context.Background(), release, "foo", tempfile)
 	require.NoError(t, err)
 }
 
@@ -436,7 +452,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 
 	t.Run("Succeeds", func(t *testing.T) {
 		release := getRelease(t)
-		err := updater.UpdateTo(context.Background(), release, tempFile)
+		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
 		assert.NoError(t, err)
 	})
 
@@ -444,7 +460,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 		release := getRelease(t)
 		release.ValidationChain[0].ValidationAssetID = 1
 
-		err := updater.UpdateTo(context.Background(), release, tempFile)
+		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
 		assert.EqualError(t, err, fmt.Sprintf("failed validating asset content %q: incorrect checksum file format", release.AssetName))
 	})
 
@@ -452,7 +468,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 		release := getRelease(t)
 		release.ValidationChain[1].ValidationAssetID = 1
 
-		err := updater.UpdateTo(context.Background(), release, tempFile)
+		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
 		assert.EqualError(t, err, "failed validating asset content \"checksums.txt\": invalid PGP signature")
 	})
 }

--- a/update_test.go
+++ b/update_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestUpdateCommandWithWrongVersion(t *testing.T) {
-	_, err := UpdateCommand(context.Background(), "file", "path", "wrong version", ParseSlug("test/test"))
+	_, err := UpdateCommand(context.Background(), UpdateCommandOpt{"file", "path", "wrong version", ParseSlug("test/test")})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, semver.ErrInvalidSemVer)
 }
@@ -30,7 +30,7 @@ func TestUpdateCommand(t *testing.T) {
 
 	filename := setupCurrentVersion(t)
 
-	rel, err := updater.UpdateCommand(context.Background(), "new_version", filename, currentVersion, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), UpdateCommandOpt{"new_version", filename, currentVersion, ParseSlug("creativeprojects/new_version")})
 	require.NoError(t, err)
 	assert.Equal(t, newVersion, rel.Version())
 
@@ -54,7 +54,7 @@ func TestUpdateViaSymlink(t *testing.T) {
 	err = os.Symlink(exePath, symPath)
 	require.NoError(t, err)
 
-	rel, err := updater.UpdateCommand(context.Background(), "new_version", symPath, currentVersion, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), UpdateCommandOpt{"new_version", symPath, currentVersion, ParseSlug("creativeprojects/new_version")})
 	require.NoError(t, err)
 	assert.Equal(t, newVersion, rel.Version())
 
@@ -91,7 +91,7 @@ func TestUpdateBrokenSymlinks(t *testing.T) {
 	defer os.Remove(xxx)
 
 	for _, filename := range []string{yyy, xxx} {
-		_, err := updater.UpdateCommand(context.Background(), filename, filename, "0.14.0", ParseSlug("owner/repo"))
+		_, err := updater.UpdateCommand(context.Background(), UpdateCommandOpt{filename, filename, "0.14.0", ParseSlug("owner/repo")})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to resolve symlink")
 	}
@@ -99,13 +99,13 @@ func TestUpdateBrokenSymlinks(t *testing.T) {
 
 func TestNotExistingExe(t *testing.T) {
 	asset := "https://github.com/rhysd-test/test-release-zip/releases/download/v1.2.3/github-release-test_linux_amd64.zip"
-	err := UpdateTo(context.Background(), asset, "not-existing-exe", "foo")
+	err := UpdateTo(context.Background(), UpdateToOpt{&Release{AssetURL: asset}, "not-existing-exe", "foo"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "executable not found in zip file")
 }
 
 func TestNotExistingCommandPath(t *testing.T) {
-	_, err := UpdateCommand(context.Background(), "not-existing-exe-name", "not-existing-command-path", "1.2.2", ParseSlug("owner/repo"))
+	_, err := UpdateCommand(context.Background(), UpdateCommandOpt{"not-existing-exe-name", "not-existing-command-path", "1.2.2", ParseSlug("owner/repo")})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "file may not exist")
 }
@@ -114,7 +114,7 @@ func TestUpdateToInvalidRelease(t *testing.T) {
 	updater, err := NewUpdater(Config{Source: &MockSource{}})
 	require.NoError(t, err)
 
-	err = updater.UpdateTo(context.Background(), nil, "", "")
+	err = updater.UpdateTo(context.Background(), UpdateToOpt{nil, "", ""})
 	assert.ErrorIs(t, err, ErrInvalidRelease)
 }
 
@@ -124,7 +124,7 @@ func TestNoReleaseFoundForUpdate(t *testing.T) {
 	updater, err := NewUpdater(Config{Source: &MockSource{}})
 	require.NoError(t, err)
 
-	rel, err := updater.UpdateCommand(context.Background(), "fake-executable", fake, finalVersion, ParseSlug("owner/repo"))
+	rel, err := updater.UpdateCommand(context.Background(), UpdateCommandOpt{"fake-executable", fake, finalVersion, ParseSlug("owner/repo")})
 	assert.NoError(t, err)
 	assert.Equal(t, finalVersion, rel.Version())
 	assert.Empty(t, rel.URL)
@@ -139,7 +139,7 @@ func TestCurrentIsTheLatest(t *testing.T) {
 	require.NoError(t, err)
 
 	latest := "1.0.0"
-	rel, err := updater.UpdateCommand(context.Background(), "new_version", filename, latest, ParseSlug("creativeprojects/new_version"))
+	rel, err := updater.UpdateCommand(context.Background(), UpdateCommandOpt{"new_version", filename, latest, ParseSlug("creativeprojects/new_version")})
 	assert.NoError(t, err)
 	assert.Equal(t, latest, rel.Version())
 	assert.NotEmpty(t, rel.URL)
@@ -193,26 +193,26 @@ func TestBrokenBinaryUpdate(t *testing.T) {
 	updater, err := NewUpdater(Config{Source: source})
 	require.NoError(t, err)
 
-	_, err = updater.UpdateCommand(context.Background(), "fake-executable", fake, "1.2.2", ParseSlug("rhysd-test/test-incorrect-release"))
+	_, err = updater.UpdateCommand(context.Background(), UpdateCommandOpt{"fake-executable", fake, "1.2.2", ParseSlug("rhysd-test/test-incorrect-release")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decompress")
 }
 
 func TestInvalidSlugForUpdate(t *testing.T) {
 	fake := filepath.FromSlash("./testdata/fake-executable")
-	_, err := UpdateCommand(context.Background(), "fake-executable", fake, "1.0.0", ParseSlug("rhysd/"))
+	_, err := UpdateCommand(context.Background(), UpdateCommandOpt{"fake-executable", fake, "1.0.0", ParseSlug("rhysd/")})
 	assert.Error(t, err)
 }
 
 func TestInvalidAssetURL(t *testing.T) {
-	err := UpdateTo(context.Background(), "https://github.com/creativeprojects/non-existing-repo/releases/download/v1.2.3/foo.zip", "foo", "foo")
+	err := UpdateTo(context.Background(), UpdateToOpt{&Release{AssetURL: "https://github.com/creativeprojects/non-existing-repo/releases/download/v1.2.3/foo.zip"}, "foo", "foo"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to download a release file")
 }
 
 func TestBrokenAsset(t *testing.T) {
 	asset := "https://github.com/rhysd-test/test-incorrect-release/releases/download/invalid/broken-zip.zip"
-	err := UpdateTo(context.Background(), asset, "foo", "foo")
+	err := UpdateTo(context.Background(), UpdateToOpt{&Release{AssetURL: asset}, "foo", "foo"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to decompress zip file")
 }
@@ -224,10 +224,10 @@ func TestBrokenGitHubEnterpriseURL(t *testing.T) {
 
 	err = up.UpdateTo(
 		context.Background(),
-		&Release{AssetURL: "https://example.com",
+		UpdateToOpt{&Release{AssetURL: "https://example.com",
 			repository: NewRepositorySlug("test", "test")},
-		"foo",
-		"foo")
+			"foo",
+			"foo"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to call GitHub Releases API for getting the asset")
 }
@@ -338,7 +338,7 @@ func TestUpdateToInvalidOwner(t *testing.T) {
 		repository: NewRepositorySlug("", "test"),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "", "")
+	err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "", ""})
 	assert.EqualError(t, err, fmt.Sprintf("failed to read asset \"\": %s", ErrIncorrectParameterOwner.Error()))
 	assert.ErrorIs(t, err, ErrIncorrectParameterOwner)
 }
@@ -350,7 +350,7 @@ func TestUpdateToInvalidRepo(t *testing.T) {
 		repository: NewRepositorySlug("test", ""),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "", "")
+	err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "", ""})
 	assert.EqualError(t, err, fmt.Sprintf("failed to read asset \"\": %s", ErrIncorrectParameterRepo.Error()))
 	assert.ErrorIs(t, err, ErrIncorrectParameterRepo)
 }
@@ -367,7 +367,7 @@ func TestUpdateToReadError(t *testing.T) {
 		repository: NewRepositorySlug("test", "test"),
 		AssetID:    123,
 	}
-	err := updater.UpdateTo(context.Background(), release, "", "")
+	err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "", ""})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errTestRead))
 }
@@ -396,7 +396,7 @@ func TestUpdateToWithWrongHash(t *testing.T) {
 		validator: &ChecksumValidator{},
 	}
 
-	err = updater.UpdateTo(context.Background(), release, "", "")
+	err = updater.UpdateTo(context.Background(), UpdateToOpt{release, "", ""})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrChecksumValidationFailed))
 }
@@ -427,7 +427,7 @@ func TestUpdateToSuccess(t *testing.T) {
 
 	tempfile := createEmptyFile(t, "foo")
 
-	err = updater.UpdateTo(context.Background(), release, "foo", tempfile)
+	err = updater.UpdateTo(context.Background(), UpdateToOpt{release, "foo", tempfile})
 	require.NoError(t, err)
 }
 
@@ -442,7 +442,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 	tempFile := createEmptyFile(t, "new_version")
 
 	getRelease := func(t *testing.T) *Release {
-		release, found, err := updater.DetectVersion(context.Background(), testGithubRepository, testVersion)
+		release, found, err := updater.DetectVersion(context.Background(), DetectVersionOpt{Repository: testGithubRepository, Version: testVersion})
 		require.NotNil(t, release)
 		require.NoError(t, err)
 		require.True(t, found)
@@ -452,7 +452,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 
 	t.Run("Succeeds", func(t *testing.T) {
 		release := getRelease(t)
-		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
+		err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "new_version", tempFile})
 		assert.NoError(t, err)
 	})
 
@@ -460,7 +460,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 		release := getRelease(t)
 		release.ValidationChain[0].ValidationAssetID = 1
 
-		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
+		err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "new_version", tempFile})
 		assert.EqualError(t, err, fmt.Sprintf("failed validating asset content %q: incorrect checksum file format", release.AssetName))
 	})
 
@@ -468,7 +468,7 @@ func TestUpdateToWithMultistepValidationChain(t *testing.T) {
 		release := getRelease(t)
 		release.ValidationChain[1].ValidationAssetID = 1
 
-		err := updater.UpdateTo(context.Background(), release, "new_version", tempFile)
+		err := updater.UpdateTo(context.Background(), UpdateToOpt{release, "new_version", tempFile})
 		assert.EqualError(t, err, "failed validating asset content \"checksums.txt\": invalid PGP signature")
 	})
 }


### PR DESCRIPTION
Sometimes it is necessary to manually specify the name of the binary file in a new release (in which case, the target name and path will stay the same as for the "current" (old) executable). This PR implements this feature.

There are some breaking changes in the public API, so it's better to make a new minor version — v1.6.0.